### PR TITLE
External resources fixes by fgsfdsfgs

### DIFF
--- a/actors/chuckya/model.inc.c
+++ b/actors/chuckya/model.inc.c
@@ -357,7 +357,7 @@ static const Vtx chuckya_seg8_vertex_0800A680[] = {
 const Gfx chuckya_seg8_dl_0800A700[] = {
     gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, chuckya_seg8_texture_08006778),
     gsDPLoadSync(),
-    gsDPLoadBlock(G_TX_LOADTILE, 0, 0, 32 * 32 - 1, CALC_DXT(32, G_IM_SIZ_16b_BYTES)),
+    gsDPLoadBlock(G_TX_LOADTILE, 0, 0, 32 * 64 - 1, CALC_DXT(32, G_IM_SIZ_16b_BYTES)),
     gsSPLight(&chuckya_seg8_lights_0800A668.l, 1),
     gsSPLight(&chuckya_seg8_lights_0800A668.a, 2),
     gsSPVertex(chuckya_seg8_vertex_0800A680, 8, 0),
@@ -375,7 +375,7 @@ const Gfx chuckya_seg8_dl_0800A758[] = {
     gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
     gsDPTileSync(),
     gsDPSetTile(G_IM_FMT_RGBA, G_IM_SIZ_16b, 8, 0, G_TX_RENDERTILE, 0, G_TX_CLAMP, 5, G_TX_NOLOD, G_TX_CLAMP, 5, G_TX_NOLOD),
-    gsDPSetTileSize(0, 0, 0, (32 - 1) << G_TEXTURE_IMAGE_FRAC, (32 - 1) << G_TEXTURE_IMAGE_FRAC),
+    gsDPSetTileSize(0, 0, 0, (32 - 1) << G_TEXTURE_IMAGE_FRAC, (64 - 1) << G_TEXTURE_IMAGE_FRAC),
     gsSPDisplayList(chuckya_seg8_dl_0800A700),
     gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_OFF),
     gsDPPipeSync(),

--- a/actors/king_bobomb/model.inc.c
+++ b/actors/king_bobomb/model.inc.c
@@ -531,7 +531,7 @@ static const Vtx king_bobomb_seg5_vertex_0500B218[] = {
 const Gfx king_bobomb_seg5_dl_0500B278[] = {
     gsDPSetTextureImage(G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, king_bobomb_seg5_texture_05004878),
     gsDPLoadSync(),
-    gsDPLoadBlock(G_TX_LOADTILE, 0, 0, 32 * 32 - 1, CALC_DXT(32, G_IM_SIZ_16b_BYTES)),
+    gsDPLoadBlock(G_TX_LOADTILE, 0, 0, 32 * 64 - 1, CALC_DXT(32, G_IM_SIZ_16b_BYTES)),
     gsSPLight(&king_bobomb_seg5_lights_0500B200.l, 1),
     gsSPLight(&king_bobomb_seg5_lights_0500B200.a, 2),
     gsSPVertex(king_bobomb_seg5_vertex_0500B218, 6, 0),
@@ -548,7 +548,7 @@ const Gfx king_bobomb_seg5_dl_0500B2D0[] = {
     gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
     gsDPTileSync(),
     gsDPSetTile(G_IM_FMT_RGBA, G_IM_SIZ_16b, 8, 0, G_TX_RENDERTILE, 0, G_TX_CLAMP, 5, G_TX_NOLOD, G_TX_CLAMP, 5, G_TX_NOLOD),
-    gsDPSetTileSize(0, 0, 0, (32 - 1) << G_TEXTURE_IMAGE_FRAC, (32 - 1) << G_TEXTURE_IMAGE_FRAC),
+    gsDPSetTileSize(0, 0, 0, (32 - 1) << G_TEXTURE_IMAGE_FRAC, (64 - 1) << G_TEXTURE_IMAGE_FRAC),
     gsSPDisplayList(king_bobomb_seg5_dl_0500B278),
     gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_OFF),
     gsDPPipeSync(),

--- a/actors/star/model.inc.c
+++ b/actors/star/model.inc.c
@@ -56,7 +56,7 @@ const Gfx star_seg3_dl_0302B870[] = {
     gsSPSetGeometryMode(G_TEXTURE_GEN),
     gsDPSetEnvColor(255, 255, 255, 255),
     gsDPSetCombineMode(G_CC_DECALFADE, G_CC_DECALFADE),
-    gsDPLoadTextureBlock(star_seg3_texture_0302A6F0, G_IM_FMT_RGBA, G_IM_SIZ_16b, 32, 64, 0, G_TX_WRAP | G_TX_NOMIRROR, G_TX_WRAP | G_TX_NOMIRROR, 5, 6, G_TX_NOLOD, G_TX_NOLOD), //! Dimensions loaded as 32x64 despite this texture having only 32x32 dimensions, harmless due to environment mapping (G_TEXTURE_GEN & gsSPTexture values)
+    gsDPLoadTextureBlock(star_seg3_texture_0302A6F0, G_IM_FMT_RGBA, G_IM_SIZ_16b, 32, 32, 0, G_TX_WRAP | G_TX_NOMIRROR, G_TX_WRAP | G_TX_NOMIRROR, 5, 6, G_TX_NOLOD, G_TX_NOLOD),
     gsSPTexture(0x07C0, 0x07C0, 0, G_TX_RENDERTILE, G_ON),
     gsSPDisplayList(star_seg3_dl_0302B7B0),
     gsDPPipeSync(),


### PR DESCRIPTION
Ignore the flag name, the screenshot was made by me some time ago. The effect here looks the same however, which is why I reused the picture.
![image](https://user-images.githubusercontent.com/12639838/87074382-0f9ddc80-c21f-11ea-8e88-51455cd70a4f.png)

Before
![image](https://user-images.githubusercontent.com/12639838/87074210-d4031280-c21e-11ea-8115-7d0de8dc4cc2.png)
After
![image](https://user-images.githubusercontent.com/12639838/87074219-d7969980-c21e-11ea-9e3b-a1fb1153af7d.png)

Before
![image](https://user-images.githubusercontent.com/12639838/87074502-4116a800-c21f-11ea-8cb4-15230f0e1f59.png)
After
![image](https://user-images.githubusercontent.com/12639838/87074570-58559580-c21f-11ea-9b51-7180d1ca30d2.png)