### PR TITLE
O2 used when not compiling for switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,9 +145,11 @@ ULTRA_BIN_DIRS := lib/bin
 
 MIPSISET := -mips2 -32
 
-
+ifeq ($(TARGET_SWITCH), 1)
 OPT_FLAGS := -O3
-
+else
+OPT_FLAGS := -O2
+endif
 
 # File dependencies and variables for specific files
 #include Makefile.split


### PR DESCRIPTION
Made an edit to Makefile that uses O2 Optimization flag when Not compiling for Switch And Uses O3 when TARGET_SWITCH=1